### PR TITLE
Fix/cli update workspaceloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,15 @@
 
 Command-line interface for SysML v2 and KerML analysis.
 
-Build from source:
-
 ```bash
+# Build the project
 cargo build --release
+
+# Run tests
+cargo test --release
+
+# Run clippy (required before commit)
+cargo clippy --all-targets -- -D warnings
 ```
 
 ## Usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,11 +22,11 @@ pub fn run_analysis(
     let mut host = AnalysisHost::new();
 
     if load_stdlib {
-        if let Some(stdlib_path) = stdlib_path {
-            let mut stdlib_loader = StdLibLoader::with_path(stdlib_path.clone());
-            stdlib_loader
-                .ensure_loaded_into_host(&mut host)
-                .expect("Failed to load stdlib");
+        if let Some(path) = stdlib_path {
+            let mut stdlib_loader = StdLibLoader::with_path(path.clone());
+            if let Err(err) = stdlib_loader.ensure_loaded_into_host(&mut host) {
+                return Err(format!("Error loading stdlib: {}", err));
+            }
         }
     }
 


### PR DESCRIPTION
Switching 'cli' to remove legacy 'semantic::Workspace' dependency.