### PR TITLE
Feat/compiler expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **YAML export format**: New `--export yaml` option for human-readable model interchange
+- **Enhanced interchange support**: Improved import/export capabilities for XMI, JSON-LD, KPAR formats
+- **Decompile command**: `--decompile` option to convert XMI/JSON-LD back to SysML text with metadata
+- **Import workspace**: `--import-workspace` flag to load interchange files for analysis with preserved element IDs
+- **Self-contained export**: `--self-contained` flag to include stdlib in exports
 - Updated README with comprehensive export format examples and documentation
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to syster-cli will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **YAML export format**: New `--export yaml` option for human-readable model interchange
+- Updated README with comprehensive export format examples and documentation
+
+### Changed
+
+- **syster-base**: Using local path dependency for development
+
 ## [0.3.0-alpha] - 2026-02-03
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syster-cli"
-version = "0.3.0-alpha"
+version = "0.3.1-alpha"
 edition = "2024"
 rust-version = "1.85"
 authors = ["jade-codes"]
@@ -21,7 +21,7 @@ name = "syster_cli"
 path = "src/lib.rs"
 
 [dependencies]
-syster-base = { path = "../base" }
+syster-base = "0.3.1-alpha"
 clap = { version = "4", features = ["derive"] }
 walkdir = "2"
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "syster_cli"
 path = "src/lib.rs"
 
 [dependencies]
-syster-base = "0.3.0-alpha"
+syster-base = { path = "../base" }
 clap = { version = "4", features = ["derive"] }
 walkdir = "2"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Syster CLI
 
-Command-line interface for SysML v2 and KerML analysis.
+Command-line interface for SysML v2 and KerML analysis and interchange.
 
 ## Installation
 
@@ -15,6 +15,8 @@ cargo build --release
 ```
 
 ## Usage
+
+### Basic Analysis
 
 ```bash
 # Analyze a single file
@@ -33,12 +35,141 @@ syster --stdlib model.sysml
 syster --stdlib-path /path/to/sysml.library model.sysml
 ```
 
+### Export Formats
+
+Export models to various interchange formats:
+
+```bash
+# Export to XMI (OMG standard)
+syster model.sysml --export xmi
+
+# Export to YAML (human-readable)
+syster model.sysml --export yaml
+
+# Export to JSON-LD (linked data)
+syster model.sysml --export jsonld
+
+# Export to KPAR (Kernel Package Archive)
+syster model.sysml --export kpar -o model.kpar
+
+# Export AST as JSON
+syster model.sysml --export-ast
+
+# Self-contained export (includes stdlib)
+syster model.sysml --export xmi --self-contained
+```
+
+### Import and Roundtrip
+
+```bash
+# Import and validate an XMI file
+syster model.xmi --import
+
+# Import into workspace for analysis
+syster model.xmi --import-workspace
+
+# Decompile XMI back to SysML text
+syster model.xmi --decompile
+```
+
+## Export Format Examples
+
+Given this SysML input:
+
+```sysml
+part def Vehicle {
+    attribute mass : Real;
+}
+```
+
+### XMI Output
+
+```xml
+<?xml version="1.0" encoding="ASCII"?>
+<sysml:PartDefinition 
+    xmlns:sysml="https://www.omg.org/spec/SysML/20250201"
+    xmi:id="68e00c54-9196-421b-9149-76783d5c26f5"
+    declaredName="Vehicle" 
+    qualifiedName="Vehicle">
+  <ownedRelatedElement xsi:type="sysml:AttributeUsage"
+      xmi:id="15e06b2e-7efc-4d4a-8c66-670ce186f57f"
+      declaredName="mass" 
+      qualifiedName="Vehicle::mass"/>
+</sysml:PartDefinition>
+```
+
+### YAML Output
+
+```yaml
+- '@type': PartDefinition
+  '@id': cc10f11d-996f-4251-8952-9723018b762d
+  name: Vehicle
+  qualifiedName: Vehicle
+  ownedMember:
+    - '@id': 48e432b9-fdfe-483a-bd2d-36e6417703b2
+
+- '@type': AttributeUsage
+  '@id': 48e432b9-fdfe-483a-bd2d-36e6417703b2
+  name: mass
+  qualifiedName: Vehicle::mass
+  owner:
+    '@id': cc10f11d-996f-4251-8952-9723018b762d
+
+- '@type': FeatureTyping
+  '@id': rel_1
+  source:
+    '@id': 48e432b9-fdfe-483a-bd2d-36e6417703b2
+  target:
+    '@id': Real
+```
+
+### AST JSON Output (`--export-ast`)
+
+```json
+{
+  "files": [
+    {
+      "path": "model.sysml",
+      "symbols": [
+        {
+          "name": "Vehicle",
+          "qualified_name": "Vehicle",
+          "kind": "PartDefinition",
+          "start_line": 1,
+          "start_col": 10,
+          "supertypes": ["Parts::Part"]
+        },
+        {
+          "name": "mass",
+          "qualified_name": "Vehicle::mass",
+          "kind": "AttributeUsage",
+          "supertypes": ["Real"]
+        }
+      ]
+    }
+  ]
+}
+```
+
 ## Features
 
 - Parse and validate SysML v2 and KerML files
-- Symbol table analysis
-- Import resolution
+- Symbol table analysis with qualified names
+- Import resolution and type checking
 - Error reporting with source locations
+- Export to XMI, YAML, JSON-LD, and KPAR formats
+- Import and validate interchange files
+- Decompile XMI back to SysML text
+- Self-contained export with embedded stdlib
+
+## Supported Formats
+
+| Format | Extension | Description |
+|--------|-----------|-------------|
+| XMI | `.xmi` | OMG XML Metadata Interchange (standard) |
+| YAML | `.yaml` | Human-readable YAML representation |
+| JSON-LD | `.jsonld` | JSON Linked Data format |
+| KPAR | `.kpar` | Kernel Package Archive (ZIP) |
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -628,8 +628,7 @@ pub fn import_model_into_host(
     if verbose {
         println!(
             "Parsed {} elements and {} relationships",
-            element_count,
-            relationship_count
+            element_count, relationship_count
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,7 +373,7 @@ pub fn export_model(
     self_contained: bool,
 ) -> Result<Vec<u8>, String> {
     use syster::interchange::{
-        JsonLd, Kpar, ModelFormat, Xmi, model_from_symbols, restore_ids_from_symbols,
+        JsonLd, Kpar, ModelFormat, Xmi, Yaml, model_from_symbols, restore_ids_from_symbols,
     };
 
     let mut host = AnalysisHost::new();
@@ -468,8 +468,9 @@ pub fn export_model(
         "xmi" => Xmi.write(&model).map_err(|e| e.to_string()),
         "kpar" => Kpar.write(&model).map_err(|e| e.to_string()),
         "jsonld" | "json-ld" => JsonLd.write(&model).map_err(|e| e.to_string()),
+        "yaml" | "yml" => Yaml.write(&model).map_err(|e| e.to_string()),
         _ => Err(format!(
-            "Unsupported format: {}. Use xmi, kpar, or jsonld.",
+            "Unsupported format: {}. Use xmi, kpar, jsonld, or yaml.",
             format
         )),
     }
@@ -490,7 +491,7 @@ pub fn export_from_host(
     self_contained: bool,
 ) -> Result<Vec<u8>, String> {
     use syster::interchange::{
-        JsonLd, Kpar, ModelFormat, Xmi, model_from_symbols, restore_ids_from_symbols,
+        JsonLd, Kpar, ModelFormat, Xmi, Yaml, model_from_symbols, restore_ids_from_symbols,
     };
 
     let analysis = host.analysis();
@@ -534,8 +535,9 @@ pub fn export_from_host(
         "xmi" => Xmi.write(&model).map_err(|e| e.to_string()),
         "kpar" => Kpar.write(&model).map_err(|e| e.to_string()),
         "jsonld" | "json-ld" => JsonLd.write(&model).map_err(|e| e.to_string()),
+        "yaml" | "yml" => Yaml.write(&model).map_err(|e| e.to_string()),
         _ => Err(format!(
-            "Unsupported format: {}. Use xmi, kpar, or jsonld.",
+            "Unsupported format: {}. Use xmi, kpar, jsonld, or yaml.",
             format
         )),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,8 @@ enum InterchangeFormat {
     Kpar,
     /// JSON-LD
     JsonLd,
+    /// YAML
+    Yaml,
 }
 
 #[derive(Parser)]
@@ -195,6 +197,7 @@ fn main() -> ExitCode {
                         InterchangeFormat::Xmi => "xmi",
                         InterchangeFormat::Kpar => "kpar",
                         InterchangeFormat::JsonLd => "jsonld",
+                        InterchangeFormat::Yaml => "yaml",
                     };
 
                     match export_from_host(&mut host, format_str, cli.verbose, cli.self_contained) {
@@ -238,6 +241,7 @@ fn main() -> ExitCode {
             InterchangeFormat::Xmi => "xmi",
             InterchangeFormat::Kpar => "kpar",
             InterchangeFormat::JsonLd => "jsonld",
+            InterchangeFormat::Yaml => "yaml",
         };
 
         match export_model(

--- a/tests/tests_cli.rs
+++ b/tests/tests_cli.rs
@@ -1357,4 +1357,466 @@ mod interchange_tests {
             filtered_xmi.len()
         );
     }
+
+    /// Test that exporting to YAML format works correctly.
+    #[test]
+    fn test_export_yaml() {
+        use std::process::Command;
+        use syster_cli::export_model;
+
+        let temp_dir = TempDir::new().unwrap();
+
+        // Create a complex SysML file with many element types
+        let sysml_path = temp_dir.path().join("model.sysml");
+        let sysml_content = r#"package AutomotiveSystem {
+    doc /* This is a comprehensive vehicle model 
+           demonstrating various SysML v2 features. */
+    
+    import ScalarValues::*;
+    
+    // Attribute definitions specializing Real
+    attribute def Mass :> Real;
+    attribute def Velocity :> Real;
+    attribute def Temperature :> Real;
+    
+    // Enumeration
+    enum def EngineState {
+        off;
+        starting;
+        running;
+        stopping;
+    }
+    
+    // Port definitions
+    port def FuelPort {
+        attribute flowRate : Real;
+        in attribute fuelIn : Real;
+        out attribute fuelOut : Real;
+    }
+    
+    port def ElectricalPort {
+        attribute voltage : Real;
+        attribute current : Real;
+    }
+    
+    port def MechanicalPort {
+        attribute torque : Real;
+        attribute rpm : Real;
+    }
+    
+    // Interface definition
+    interface def PowerInterface {
+        end supplierPort : ElectricalPort;
+        end consumerPort : ElectricalPort;
+    }
+    
+    // Part definitions with features
+    abstract part def Component {
+        attribute mass : Mass;
+        attribute serialNumber : String;
+    }
+    
+    part def Cylinder :> Component {
+        attribute bore : Real;
+        attribute stroke : Real;
+        attribute compressionRatio : Real;
+    }
+    
+    part def FuelInjector :> Component {
+        attribute sprayAngle : Real;
+        port fuelIn : FuelPort;
+    }
+    
+    part def Engine :> Component {
+        attribute displacement : Real;
+        attribute maxPower : Real;
+        attribute state : EngineState;
+        
+        port fuelIntake : FuelPort;
+        port electricalConn : ElectricalPort;
+        
+        // Nested parts
+        part cylinder[4] : Cylinder;
+        part fuelInjector[4] : FuelInjector;
+        
+        // State machine
+        state def EngineStates {
+            entry state off;
+            state starting;
+            state running;
+            state stopping;
+            
+            transition off_to_starting
+                first off
+                then starting;
+            
+            transition starting_to_running
+                first starting
+                then running;
+            
+            transition running_to_stopping
+                first running
+                then stopping;
+            
+            transition stopping_to_off
+                first stopping
+                then off;
+        }
+    }
+    
+    part def Transmission :> Component {
+        attribute gearCount : Integer;
+        attribute currentGear : Integer;
+        port inputShaft : MechanicalPort;
+        port outputShaft : MechanicalPort;
+    }
+    
+    part def Battery :> Component {
+        attribute capacity : Real;
+        attribute voltage : Real;
+        attribute chargeLevel : Real;
+        port powerOut : ElectricalPort;
+    }
+    
+    // Connection definition
+    connection def PowerConnection :> PowerInterface {
+        end supplierPort : ElectricalPort;
+        end consumerPort : ElectricalPort;
+    }
+    
+    // Top-level vehicle assembly
+    part def Vehicle :> Component {
+        attribute vin : String;
+        attribute modelYear : Integer;
+        attribute totalMass : Mass;
+        attribute currentVelocity : Velocity;
+        
+        // Major subsystems
+        part engine : Engine;
+        part transmission : Transmission;
+        part battery : Battery;
+        
+        // Connections between parts
+        connection enginePower : PowerConnection
+            connect battery.powerOut to engine.electricalConn;
+    }
+    
+    // Use case for vehicle operation
+    use case def DriveVehicle {
+        subject vehicle : Vehicle;
+        
+        actor driver;
+        
+        include use case startEngine;
+        include use case accelerate;
+        include use case brake;
+        include use case stopEngine;
+    }
+    
+    // Requirements
+    requirement def SafetyRequirement {
+        doc /* All safety requirements for the vehicle */
+        
+        attribute criticality : String;
+    }
+    
+    requirement vehicleSafety : SafetyRequirement {
+        doc /* The vehicle shall meet all applicable safety standards. */
+    }
+    
+    // Analysis case
+    analysis def ThermalAnalysis {
+        subject vehicle : Vehicle;
+        
+        return result : Real;
+    }
+    
+    // View and viewpoint
+    viewpoint def SystemArchitectViewpoint {
+        doc /* Stakeholder view for system architects */
+    }
+    
+    view def VehicleOverview {
+        expose Vehicle;
+        expose Engine;
+        expose Transmission;
+    }
+}"#;
+        fs::write(&sysml_path, sysml_content).unwrap();
+
+        // Get stdlib path
+        let local_stdlib = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("base/sysml.library");
+
+        let stdlib_dir = if local_stdlib.exists() {
+            local_stdlib
+        } else {
+            let stdlib_clone_dir = temp_dir.path().join("sysml-release");
+            let status = Command::new("git")
+                .args([
+                    "clone",
+                    "--depth=1",
+                    "https://github.com/Systems-Modeling/SysML-v2-Release.git",
+                    stdlib_clone_dir.to_str().unwrap(),
+                ])
+                .status()
+                .expect("Failed to run git clone");
+
+            if !status.success() {
+                panic!("Failed to clone SysML-v2-Release repository");
+            }
+
+            stdlib_clone_dir.join("sysml.library")
+        };
+
+        // Export to YAML (with stdlib loaded but filtered out)
+        let yaml_bytes = export_model(&sysml_path, "yaml", false, true, Some(&stdlib_dir), false)
+            .expect("Should export to YAML");
+
+        let yaml_str = String::from_utf8(yaml_bytes).expect("Should be valid UTF-8");
+
+        // Print the YAML output for inspection
+        println!("=== YAML Output ===\n{}\n=== End YAML ===", yaml_str);
+
+        // Verify YAML structure - basic types
+        assert!(yaml_str.contains("type: Package"), "Should have Package type");
+        assert!(
+            yaml_str.contains("type: PartDefinition"),
+            "Should have PartDefinition type"
+        );
+        assert!(
+            yaml_str.contains("type: PortDefinition"),
+            "Should have PortDefinition type"
+        );
+        assert!(
+            yaml_str.contains("type: AttributeDefinition"),
+            "Should have AttributeDefinition type"
+        );
+        assert!(
+            yaml_str.contains("type: InterfaceDefinition"),
+            "Should have InterfaceDefinition type"
+        );
+        assert!(
+            yaml_str.contains("type: ConnectionDefinition"),
+            "Should have ConnectionDefinition type"
+        );
+        assert!(
+            yaml_str.contains("type: RequirementDefinition"),
+            "Should have RequirementDefinition type"
+        );
+        assert!(
+            yaml_str.contains("type: UseCaseDefinition"),
+            "Should have UseCaseDefinition type"
+        );
+        assert!(
+            yaml_str.contains("type: ViewDefinition"),
+            "Should have ViewDefinition type"
+        );
+        assert!(
+            yaml_str.contains("type: ViewpointDefinition"),
+            "Should have ViewpointDefinition type"
+        );
+
+        // Verify element names are present
+        assert!(
+            yaml_str.contains("name: AutomotiveSystem"),
+            "Should contain AutomotiveSystem package"
+        );
+        assert!(
+            yaml_str.contains("name: Vehicle"),
+            "Should contain Vehicle part def"
+        );
+        assert!(
+            yaml_str.contains("name: Engine"),
+            "Should contain Engine part def"
+        );
+        assert!(
+            yaml_str.contains("name: Transmission"),
+            "Should contain Transmission part def"
+        );
+        assert!(
+            yaml_str.contains("name: Battery"),
+            "Should contain Battery part def"
+        );
+        assert!(
+            yaml_str.contains("name: FuelPort"),
+            "Should contain FuelPort port def"
+        );
+        assert!(
+            yaml_str.contains("name: ElectricalPort"),
+            "Should contain ElectricalPort port def"
+        );
+        assert!(
+            yaml_str.contains("name: PowerInterface"),
+            "Should contain PowerInterface interface def"
+        );
+        assert!(
+            yaml_str.contains("name: DriveVehicle"),
+            "Should contain DriveVehicle use case"
+        );
+        assert!(
+            yaml_str.contains("name: SafetyRequirement"),
+            "Should contain SafetyRequirement requirement def"
+        );
+
+        // Verify ownership structure
+        assert!(
+            yaml_str.contains("owner:"),
+            "Should have owner references"
+        );
+        assert!(
+            yaml_str.contains("ownedMember:"),
+            "Should have ownedMember arrays"
+        );
+        
+        // Verify qualified names are present
+        assert!(
+            yaml_str.contains("qualifiedName: AutomotiveSystem::Vehicle"),
+            "Should have qualified name for Vehicle"
+        );
+        assert!(
+            yaml_str.contains("qualifiedName: AutomotiveSystem::Engine"),
+            "Should have qualified name for Engine"
+        );
+        
+        // Verify stdlib import is present
+        assert!(
+            yaml_str.contains("name: ScalarValues"),
+            "Should contain ScalarValues import"
+        );
+        
+        // Verify specialization of Real is captured
+        // Mass, Velocity, Temperature all specialize Real from ScalarValues
+        assert!(
+            yaml_str.contains("qualifiedName: AutomotiveSystem::Mass"),
+            "Should have Mass attribute def"
+        );
+        assert!(
+            yaml_str.contains("qualifiedName: AutomotiveSystem::Velocity"),
+            "Should have Velocity attribute def"
+        );
+        assert!(
+            yaml_str.contains("qualifiedName: AutomotiveSystem::Temperature"),
+            "Should have Temperature attribute def"
+        );
+        
+        // Verify the specializes relationship is present for Real
+        assert!(
+            yaml_str.contains("specializes:"),
+            "Should have specializes relationships"
+        );
+        assert!(
+            yaml_str.contains("- Real"),
+            "Should show specialization of Real from stdlib"
+        );
+
+        // Verify it parses back (round-trip)
+        use syster::interchange::{ModelFormat, Yaml};
+        let model = Yaml
+            .read(yaml_str.as_bytes())
+            .expect("Should parse YAML back");
+        
+        // Complex model should have many elements
+        assert!(
+            model.elements.len() >= 20,
+            "Should have at least 20 elements, got {}",
+            model.elements.len()
+        );
+        
+        // Print element count by type for inspection
+        println!("Total elements in YAML model: {}", model.elements.len());
+    }
+
+    /// Test YAML export with stdlib references.
+    #[test]
+    fn test_export_yaml_with_stdlib_reference() {
+        use std::process::Command;
+        use syster_cli::export_model;
+
+        let temp_dir = TempDir::new().unwrap();
+
+        // Create a SysML file that references Real from the stdlib
+        let sysml_path = temp_dir.path().join("model.sysml");
+        let sysml_content = r#"package MeasurementSystem {
+    import ScalarValues::*;
+    
+    attribute def Temperature :> Real;
+    
+    part def Thermometer {
+        attribute currentTemp : Temperature;
+    }
+}"#;
+        fs::write(&sysml_path, sysml_content).unwrap();
+
+        // Try to use the local stdlib
+        let local_stdlib = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("base/sysml.library");
+
+        let stdlib_dir = if local_stdlib.exists() {
+            local_stdlib
+        } else {
+            let stdlib_clone_dir = temp_dir.path().join("sysml-release");
+            let status = Command::new("git")
+                .args([
+                    "clone",
+                    "--depth=1",
+                    "https://github.com/Systems-Modeling/SysML-v2-Release.git",
+                    stdlib_clone_dir.to_str().unwrap(),
+                ])
+                .status()
+                .expect("Failed to run git clone");
+
+            if !status.success() {
+                panic!("Failed to clone SysML-v2-Release repository");
+            }
+
+            stdlib_clone_dir.join("sysml.library")
+        };
+
+        // Export to YAML (filtered, no stdlib)
+        let yaml_bytes = export_model(&sysml_path, "yaml", false, true, Some(&stdlib_dir), false)
+            .expect("Should export YAML with stdlib reference");
+
+        let yaml_str = String::from_utf8(yaml_bytes).expect("Should be valid UTF-8");
+
+        println!(
+            "=== YAML with stdlib ref ===\n{}\n=== End YAML ===",
+            yaml_str
+        );
+
+        // Verify user elements are present
+        assert!(
+            yaml_str.contains("MeasurementSystem"),
+            "Should contain MeasurementSystem package"
+        );
+        assert!(
+            yaml_str.contains("Thermometer"),
+            "Should contain Thermometer part def"
+        );
+        assert!(
+            yaml_str.contains("Temperature"),
+            "Should contain Temperature attribute def"
+        );
+
+        // Verify stdlib package definitions are NOT included (only the import reference)
+        // The import itself will contain "ScalarValues" in its name, but the
+        // actual ScalarValues package from stdlib should not be exported
+        assert!(
+            !yaml_str.contains("type: LibraryPackage"),
+            "Should NOT contain LibraryPackage (stdlib)"
+        );
+
+        // Count element types - should only have user elements
+        let part_def_count = yaml_str.matches("type: PartDefinition").count();
+        let attr_def_count = yaml_str.matches("type: AttributeDefinition").count();
+        assert_eq!(part_def_count, 1, "Should have exactly 1 PartDefinition");
+        assert_eq!(
+            attr_def_count, 1,
+            "Should have exactly 1 AttributeDefinition"
+        );
+    }
 }

--- a/tests/tests_cli.rs
+++ b/tests/tests_cli.rs
@@ -1082,8 +1082,8 @@ mod interchange_tests {
 
         // Verify it's valid XMI structure
         assert!(
-            xmi_str.contains("xmi:XMI"),
-            "Should be valid XMI with namespace"
+            xmi_str.contains("xmi:version") || xmi_str.contains("xmi:XMI"),
+            "Should be valid XMI with version or XMI root"
         );
         assert!(
             xmi_str.contains("xmlns:sysml"),
@@ -1581,41 +1581,41 @@ mod interchange_tests {
         println!("=== YAML Output ===\n{}\n=== End YAML ===", yaml_str);
 
         // Verify YAML structure - basic types
-        assert!(yaml_str.contains("type: Package"), "Should have Package type");
+        assert!(yaml_str.contains("'@type': Package"), "Should have Package type");
         assert!(
-            yaml_str.contains("type: PartDefinition"),
+            yaml_str.contains("'@type': PartDefinition"),
             "Should have PartDefinition type"
         );
         assert!(
-            yaml_str.contains("type: PortDefinition"),
+            yaml_str.contains("'@type': PortDefinition"),
             "Should have PortDefinition type"
         );
         assert!(
-            yaml_str.contains("type: AttributeDefinition"),
+            yaml_str.contains("'@type': AttributeDefinition"),
             "Should have AttributeDefinition type"
         );
         assert!(
-            yaml_str.contains("type: InterfaceDefinition"),
+            yaml_str.contains("'@type': InterfaceDefinition"),
             "Should have InterfaceDefinition type"
         );
         assert!(
-            yaml_str.contains("type: ConnectionDefinition"),
+            yaml_str.contains("'@type': ConnectionDefinition"),
             "Should have ConnectionDefinition type"
         );
         assert!(
-            yaml_str.contains("type: RequirementDefinition"),
+            yaml_str.contains("'@type': RequirementDefinition"),
             "Should have RequirementDefinition type"
         );
         assert!(
-            yaml_str.contains("type: UseCaseDefinition"),
+            yaml_str.contains("'@type': UseCaseDefinition"),
             "Should have UseCaseDefinition type"
         );
         assert!(
-            yaml_str.contains("type: ViewDefinition"),
+            yaml_str.contains("'@type': ViewDefinition"),
             "Should have ViewDefinition type"
         );
         assert!(
-            yaml_str.contains("type: ViewpointDefinition"),
+            yaml_str.contains("'@type': ViewpointDefinition"),
             "Should have ViewpointDefinition type"
         );
 
@@ -1701,15 +1701,11 @@ mod interchange_tests {
             yaml_str.contains("qualifiedName: AutomotiveSystem::Temperature"),
             "Should have Temperature attribute def"
         );
-        
-        // Verify the specializes relationship is present for Real
+
+        // Verify specialization relationships are present (new format uses separate relationship objects)
         assert!(
-            yaml_str.contains("specializes:"),
-            "Should have specializes relationships"
-        );
-        assert!(
-            yaml_str.contains("- Real"),
-            "Should show specialization of Real from stdlib"
+            yaml_str.contains("'@type': Specialization"),
+            "Should have Specialization relationships"
         );
 
         // Verify it parses back (round-trip)
@@ -1806,13 +1802,13 @@ mod interchange_tests {
         // The import itself will contain "ScalarValues" in its name, but the
         // actual ScalarValues package from stdlib should not be exported
         assert!(
-            !yaml_str.contains("type: LibraryPackage"),
+            !yaml_str.contains("'@type': LibraryPackage"),
             "Should NOT contain LibraryPackage (stdlib)"
         );
 
         // Count element types - should only have user elements
-        let part_def_count = yaml_str.matches("type: PartDefinition").count();
-        let attr_def_count = yaml_str.matches("type: AttributeDefinition").count();
+        let part_def_count = yaml_str.matches("'@type': PartDefinition").count();
+        let attr_def_count = yaml_str.matches("'@type': AttributeDefinition").count();
         assert_eq!(part_def_count, 1, "Should have exactly 1 PartDefinition");
         assert_eq!(
             attr_def_count, 1,

--- a/tests/tests_cli.rs
+++ b/tests/tests_cli.rs
@@ -709,7 +709,7 @@ fn test_export_ast_single_file() {
 
     // Check Vehicle symbol
     let vehicle = symbols.iter().find(|s| s["name"] == "Vehicle").unwrap();
-    assert_eq!(vehicle["kind"], "PartDef");
+    assert_eq!(vehicle["kind"], "PartDefinition");
     assert_eq!(vehicle["qualified_name"], "Vehicle");
 }
 
@@ -1581,7 +1581,10 @@ mod interchange_tests {
         println!("=== YAML Output ===\n{}\n=== End YAML ===", yaml_str);
 
         // Verify YAML structure - basic types
-        assert!(yaml_str.contains("'@type': Package"), "Should have Package type");
+        assert!(
+            yaml_str.contains("'@type': Package"),
+            "Should have Package type"
+        );
         assert!(
             yaml_str.contains("'@type': PartDefinition"),
             "Should have PartDefinition type"
@@ -1662,15 +1665,12 @@ mod interchange_tests {
         );
 
         // Verify ownership structure
-        assert!(
-            yaml_str.contains("owner:"),
-            "Should have owner references"
-        );
+        assert!(yaml_str.contains("owner:"), "Should have owner references");
         assert!(
             yaml_str.contains("ownedMember:"),
             "Should have ownedMember arrays"
         );
-        
+
         // Verify qualified names are present
         assert!(
             yaml_str.contains("qualifiedName: AutomotiveSystem::Vehicle"),
@@ -1680,13 +1680,13 @@ mod interchange_tests {
             yaml_str.contains("qualifiedName: AutomotiveSystem::Engine"),
             "Should have qualified name for Engine"
         );
-        
+
         // Verify stdlib import is present
         assert!(
             yaml_str.contains("name: ScalarValues"),
             "Should contain ScalarValues import"
         );
-        
+
         // Verify specialization of Real is captured
         // Mass, Velocity, Temperature all specialize Real from ScalarValues
         assert!(
@@ -1713,14 +1713,14 @@ mod interchange_tests {
         let model = Yaml
             .read(yaml_str.as_bytes())
             .expect("Should parse YAML back");
-        
+
         // Complex model should have many elements
         assert!(
             model.elements.len() >= 20,
             "Should have at least 20 elements, got {}",
             model.elements.len()
         );
-        
+
         // Print element count by type for inspection
         println!("Total elements in YAML model: {}", model.elements.len());
     }


### PR DESCRIPTION
This pull request adds support for exporting models in YAML format to the `syster_cli` tool. The changes update both the CLI logic and the underlying library code to recognize and handle YAML as a valid interchange format, alongside existing formats like XMI, KPAR, and JSON-LD.

**YAML export support:**

* Added `Yaml` to the list of supported formats in the `InterchangeFormat` enum in `src/main.rs`, and updated CLI logic to handle YAML exports. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR30-R31) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR200) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR244)
* Updated the `export_model` and `export_from_host` functions in `src/lib.rs` to include YAML in format selection and error messages, and imported the `Yaml` type from `syster::interchange`. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L376-R376) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R471-R473) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L493-R494) [[4]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R538-R540)

**Dependency management:**

* Changed the `syster-base` dependency in `Cargo.toml` to use a local path instead of a published version for easier development and testing.