### PR TITLE
chore: bump syster-base to 0.4.1-alpha

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "syster_cli"
 path = "src/lib.rs"
 
 [dependencies]
-syster-base = "0.4.0-alpha"
+syster-base = "0.4.1-alpha"
 clap = { version = "4", features = ["derive"] }
 walkdir = "2"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Updates the `syster-base` dependency from `0.4.0-alpha` to `0.4.1-alpha` (published on crates.io).

### Validation
- `cargo build` ✅
- `cargo clippy --all-targets -- -D warnings` ✅

No source changes were needed — the base API additions don't affect cli.

🤖 Generated with [Claude Code](https://claude.com/claude-code)